### PR TITLE
Add Docker and k3s deployment configs

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+__pycache__
+*.pyc
+*.pyo
+*.pyd
+.cache
+.git
+.gitignore
+config.yaml

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy application code
+COPY . .
+
+# Ensure start script is executable
+RUN chmod +x /app/start.sh
+
+ENTRYPOINT ["/app/start.sh"]

--- a/README.md
+++ b/README.md
@@ -1,0 +1,35 @@
+# Music Bot
+
+This repository contains a Telegram music bot. The Dockerfile and Kubernetes manifests
+allow running the bot in a k3s cluster.
+
+## Building the Docker image
+
+```bash
+docker build -t music-bot:latest .
+```
+
+## Configuration in k3s
+
+1. Create Kubernetes secrets with your API keys and tokens:
+
+```bash
+kubectl apply -f k8s/secret.yaml
+```
+
+2. Create the ConfigMap with the bot configuration template:
+
+```bash
+kubectl apply -f k8s/configmap.yaml
+```
+
+3. Deploy the bot using the provided deployment manifest (adjust the `image` field
+   to match your registry):
+
+```bash
+kubectl apply -f k8s/deployment.yaml
+```
+
+The bot expects a persistent volume claim named `music-bot-pvc` for storing
+downloads. A secret named `youtube-cookies` can be used to provide yt-dlp cookie
+files if needed.

--- a/config-template.yaml
+++ b/config-template.yaml
@@ -1,0 +1,47 @@
+telegram_token: "${TELEGRAM_TOKEN}"
+allowed_users:
+  # IDs of Telegram users allowed to use the bot
+  - 123456789
+  - 987654321
+download_dir: "/data"
+
+spotify:
+  client_id: "${SPOTIFY_CLIENT_ID}"
+  client_secret: "${SPOTIFY_CLIENT_SECRET}"
+
+yandex:
+  username: "${YANDEX_USERNAME}"
+  password: "${YANDEX_PASSWORD}"
+
+cookies:
+  # Path inside the container for yt-dlp cookies (optional)
+  youtube: "/config/youtube_cookies.txt"
+
+file_upload:
+  subdir: "Telegram Uploads"
+  allowed_exts:
+    - .mp3
+    - .flac
+    - .m4a
+    - .aac
+    - .ogg
+    - .opus
+    - .wav
+    - .aiff
+    - .aif
+    - .wma
+    - .dsf
+    - .dff
+    - .mka
+
+metadata_lookup:
+  enable: true
+  min_confidence: 0.5
+  acoustid_api_key: "${ACOUSTID_KEY}"
+  musicbrainz_useragent: "MusicBot/0.1 (youremail@example.com)"
+  lastfm_api_key: "${LASTFM_API_KEY}"
+  discogs:
+    user_agent: "MusicBot/0.1"
+    token: "${DISCOGS_TOKEN}"
+  prefer_existing_tags: true
+  fetch_cover_art: true

--- a/k8s/configmap.yaml
+++ b/k8s/configmap.yaml
@@ -1,0 +1,53 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: music-bot-config
+data:
+  config-template.yaml: |
+    telegram_token: "${TELEGRAM_TOKEN}"
+    allowed_users:
+      # IDs of Telegram users allowed to use the bot
+      - 123456789
+      - 987654321
+    download_dir: "/data"
+    
+    spotify:
+      client_id: "${SPOTIFY_CLIENT_ID}"
+      client_secret: "${SPOTIFY_CLIENT_SECRET}"
+    
+    yandex:
+      username: "${YANDEX_USERNAME}"
+      password: "${YANDEX_PASSWORD}"
+    
+    cookies:
+      # Path inside the container for yt-dlp cookies (optional)
+      youtube: "/config/youtube_cookies.txt"
+    
+    file_upload:
+      subdir: "Telegram Uploads"
+      allowed_exts:
+        - .mp3
+        - .flac
+        - .m4a
+        - .aac
+        - .ogg
+        - .opus
+        - .wav
+        - .aiff
+        - .aif
+        - .wma
+        - .dsf
+        - .dff
+        - .mka
+    
+    metadata_lookup:
+      enable: true
+      min_confidence: 0.5
+      acoustid_api_key: "${ACOUSTID_KEY}"
+      musicbrainz_useragent: "MusicBot/0.1 (youremail@example.com)"
+      lastfm_api_key: "${LASTFM_API_KEY}"
+      discogs:
+        user_agent: "MusicBot/0.1"
+        token: "${DISCOGS_TOKEN}"
+      prefer_existing_tags: true
+      fetch_cover_art: true

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -1,0 +1,76 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: music-bot
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: music-bot
+  template:
+    metadata:
+      labels:
+        app: music-bot
+    spec:
+      containers:
+        - name: bot
+          image: your-registry/music-bot:latest
+          env:
+            - name: TELEGRAM_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: music-bot-secrets
+                  key: TELEGRAM_TOKEN
+            - name: SPOTIFY_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: music-bot-secrets
+                  key: SPOTIFY_CLIENT_ID
+            - name: SPOTIFY_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: music-bot-secrets
+                  key: SPOTIFY_CLIENT_SECRET
+            - name: ACOUSTID_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: music-bot-secrets
+                  key: ACOUSTID_KEY
+            - name: LASTFM_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: music-bot-secrets
+                  key: LASTFM_API_KEY
+            - name: DISCOGS_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: music-bot-secrets
+                  key: DISCOGS_TOKEN
+            - name: YANDEX_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: music-bot-secrets
+                  key: YANDEX_USERNAME
+            - name: YANDEX_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: music-bot-secrets
+                  key: YANDEX_PASSWORD
+          volumeMounts:
+            - name: config-volume
+              mountPath: /app/config-template.yaml
+              subPath: config-template.yaml
+            - name: data-volume
+              mountPath: /data
+            - name: cookie-volume
+              mountPath: /config
+      volumes:
+        - name: config-volume
+          configMap:
+            name: music-bot-config
+        - name: data-volume
+          persistentVolumeClaim:
+            claimName: music-bot-pvc
+        - name: cookie-volume
+          secret:
+            secretName: youtube-cookies

--- a/k8s/secret.yaml
+++ b/k8s/secret.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: music-bot-secrets
+type: Opaque
+data:
+  TELEGRAM_TOKEN: <base64-token>
+  SPOTIFY_CLIENT_ID: <base64-client-id>
+  SPOTIFY_CLIENT_SECRET: <base64-client-secret>
+  ACOUSTID_KEY: <base64-acoustid-key>
+  LASTFM_API_KEY: <base64-lastfm-key>
+  DISCOGS_TOKEN: <base64-discogs-token>
+  YANDEX_USERNAME: <base64-yandex-username>
+  YANDEX_PASSWORD: <base64-yandex-password>

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+# Generate config.yaml from template using environment variables
+if [ ! -f config.yaml ]; then
+    if [ -f config-template.yaml ]; then
+        envsubst < config-template.yaml > config.yaml
+    fi
+fi
+exec python main.py


### PR DESCRIPTION
## Summary
- containerize the bot with a Dockerfile and start script
- provide a template `config-template.yaml` for environment variable substitution
- add Kubernetes manifests for ConfigMap, Secrets and Deployment
- add README with build/deploy instructions

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_687cd48ca560832380ab73c4e691ff4b